### PR TITLE
Only transfer Execution stack

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -433,13 +433,17 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		ret   []byte
 		vmerr error // vm errors do not effect consensus and are therefore not assigned to err
 	)
-	if contractCreation {
-		ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, msg.Value)
-	} else {
-		// Increment the nonce for the next transaction
-		st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
-		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, msg.Value)
-	}
+
+	//@p2perc20rollup Don't consider contractCreation state transitions.
+
+	// if contractCreation {
+	// 	ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, msg.Value)
+	// } else {
+	// }
+	// Increment the nonce for the next transaction
+	st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
+	ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, msg.Value)
+
 
 	// if deposit: skip refunds, skip tipping coinbase
 	// Regolith changes this behaviour to report the actual gasUsed instead of always reporting all gas used.

--- a/core/types/rollup_l1_cost.go
+++ b/core/types/rollup_l1_cost.go
@@ -77,7 +77,11 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 func L1Cost(rollupDataGas uint64, l1BaseFee, overhead, scalar *big.Int) *big.Int {
 	l1GasUsed := new(big.Int).SetUint64(rollupDataGas)
 	l1GasUsed = l1GasUsed.Add(l1GasUsed, overhead)
+	//@p2perc20rollup multiply the estimated cost by the exchange rate
+	// between L1 native gas token and erc20 token used as native in rollup.
+	priceOfL1NativeToL2ERC20 := big.NewInt(18)
 	l1Cost := l1GasUsed.Mul(l1GasUsed, l1BaseFee)
+	l1Cost = l1Cost.Mul(l1Cost, priceOfL1NativeToL2ERC20)
 	l1Cost = l1Cost.Mul(l1Cost, scalar)
 	return l1Cost.Div(l1Cost, big.NewInt(1_000_000))
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -574,48 +574,50 @@ func opGas(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 }
 
 func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
-		return nil, ErrWriteProtection
-	}
-	var (
-		value        = scope.Stack.pop()
-		offset, size = scope.Stack.pop(), scope.Stack.pop()
-		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
-		gas          = scope.Contract.Gas
-	)
-	if interpreter.evm.chainRules.IsEIP150 {
-		gas -= gas / 64
-	}
-	// reuse size int for stackvalue
-	stackvalue := size
+	//@p2perc20rollup Don't allow deployment of contracts.
 
-	scope.Contract.UseGas(gas)
-	//TODO: use uint256.Int instead of converting with toBig()
-	var bigVal = big0
-	if !value.IsZero() {
-		bigVal = value.ToBig()
-	}
+	// if interpreter.readOnly {
+	// 	return nil, ErrWriteProtection
+	// }
+	// var (
+	// 	value        = scope.Stack.pop()
+	// 	offset, size = scope.Stack.pop(), scope.Stack.pop()
+	// 	input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+	// 	gas          = scope.Contract.Gas
+	// )
+	// if interpreter.evm.chainRules.IsEIP150 {
+	// 	gas -= gas / 64
+	// }
+	// // reuse size int for stackvalue
+	// stackvalue := size
 
-	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, bigVal)
-	// Push item on the stack based on the returned error. If the ruleset is
-	// homestead we must check for CodeStoreOutOfGasError (homestead only
-	// rule) and treat as an error, if the ruleset is frontier we must
-	// ignore this error and pretend the operation was successful.
-	if interpreter.evm.chainRules.IsHomestead && suberr == ErrCodeStoreOutOfGas {
-		stackvalue.Clear()
-	} else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
-		stackvalue.Clear()
-	} else {
-		stackvalue.SetBytes(addr.Bytes())
-	}
-	scope.Stack.push(&stackvalue)
-	scope.Contract.Gas += returnGas
+	// scope.Contract.UseGas(gas)
+	// //TODO: use uint256.Int instead of converting with toBig()
+	// var bigVal = big0
+	// if !value.IsZero() {
+	// 	bigVal = value.ToBig()
+	// }
 
-	if suberr == ErrExecutionReverted {
-		interpreter.returnData = res // set REVERT data to return data buffer
-		return res, nil
-	}
-	interpreter.returnData = nil // clear dirty return data buffer
+	// res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, bigVal)
+	// // Push item on the stack based on the returned error. If the ruleset is
+	// // homestead we must check for CodeStoreOutOfGasError (homestead only
+	// // rule) and treat as an error, if the ruleset is frontier we must
+	// // ignore this error and pretend the operation was successful.
+	// if interpreter.evm.chainRules.IsHomestead && suberr == ErrCodeStoreOutOfGas {
+	// 	stackvalue.Clear()
+	// } else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
+	// 	stackvalue.Clear()
+	// } else {
+	// 	stackvalue.SetBytes(addr.Bytes())
+	// }
+	// scope.Stack.push(&stackvalue)
+	// scope.Contract.Gas += returnGas
+
+	// if suberr == ErrExecutionReverted {
+	// 	interpreter.returnData = res // set REVERT data to return data buffer
+	// 	return res, nil
+	// }
+	// interpreter.returnData = nil // clear dirty return data buffer
 	return nil, nil
 }
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -622,42 +622,44 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
-		return nil, ErrWriteProtection
-	}
-	var (
-		endowment    = scope.Stack.pop()
-		offset, size = scope.Stack.pop(), scope.Stack.pop()
-		salt         = scope.Stack.pop()
-		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
-		gas          = scope.Contract.Gas
-	)
-	// Apply EIP150
-	gas -= gas / 64
-	scope.Contract.UseGas(gas)
-	// reuse size int for stackvalue
-	stackvalue := size
-	//TODO: use uint256.Int instead of converting with toBig()
-	bigEndowment := big0
-	if !endowment.IsZero() {
-		bigEndowment = endowment.ToBig()
-	}
-	res, addr, returnGas, suberr := interpreter.evm.Create2(scope.Contract, input, gas,
-		bigEndowment, &salt)
-	// Push item on the stack based on the returned error.
-	if suberr != nil {
-		stackvalue.Clear()
-	} else {
-		stackvalue.SetBytes(addr.Bytes())
-	}
-	scope.Stack.push(&stackvalue)
-	scope.Contract.Gas += returnGas
+	//@p2perc20rollup Don't allow deployment of contracts.
 
-	if suberr == ErrExecutionReverted {
-		interpreter.returnData = res // set REVERT data to return data buffer
-		return res, nil
-	}
-	interpreter.returnData = nil // clear dirty return data buffer
+	// if interpreter.readOnly {
+	// 	return nil, ErrWriteProtection
+	// }
+	// var (
+	// 	endowment    = scope.Stack.pop()
+	// 	offset, size = scope.Stack.pop(), scope.Stack.pop()
+	// 	salt         = scope.Stack.pop()
+	// 	input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+	// 	gas          = scope.Contract.Gas
+	// )
+	// // Apply EIP150
+	// gas -= gas / 64
+	// scope.Contract.UseGas(gas)
+	// // reuse size int for stackvalue
+	// stackvalue := size
+	// //TODO: use uint256.Int instead of converting with toBig()
+	// bigEndowment := big0
+	// if !endowment.IsZero() {
+	// 	bigEndowment = endowment.ToBig()
+	// }
+	// res, addr, returnGas, suberr := interpreter.evm.Create2(scope.Contract, input, gas,
+	// 	bigEndowment, &salt)
+	// // Push item on the stack based on the returned error.
+	// if suberr != nil {
+	// 	stackvalue.Clear()
+	// } else {
+	// 	stackvalue.SetBytes(addr.Bytes())
+	// }
+	// scope.Stack.push(&stackvalue)
+	// scope.Contract.Gas += returnGas
+
+	// if suberr == ErrExecutionReverted {
+	// 	interpreter.returnData = res // set REVERT data to return data buffer
+	// 	return res, nil
+	// }
+	// interpreter.returnData = nil // clear dirty return data buffer
 	return nil, nil
 }
 


### PR DESCRIPTION
This pull request implements changes to the op-geth execution stack, in order to **ONLY** allow native token transfers.